### PR TITLE
Upgrade to minimatch@3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgraded `minimatch` to `^3.0.3` from `^3.0.0` for [RegExp DOS fix](https://nodesecurity.io/advisories/minimatch_regular-expression-denial-of-service).
+
 ## 0.12.1 - 2016-07-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "commander": "^2.9.0",
     "cuint": "^0.2.1",
     "glob": "^6.0.4",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",
     "mksnapshot": "^0.3.0",
     "tmp": "0.0.28"


### PR DESCRIPTION
Addresses insecure dependency warnings related to https://nodesecurity.io/advisories/minimatch_regular-expression-denial-of-service