### PR TITLE
Output help information when undefined command is used

### DIFF
--- a/bin/asar
+++ b/bin/asar
@@ -59,6 +59,11 @@ program.command('extract <archive> <dest>')
          asar.extractAll(archive, dest);
        });
 
+program.command('*')
+       .action(function(cmd) {
+         console.log('asar: \'%s\' is not an asar command. See \'asar --help\'.', cmd)
+       });
+
 program.parse(process.argv);
 
 if (program.args.length == 0)


### PR DESCRIPTION
In this patch, help information is outputted when an undefined command is used. The motivation for this change is that I performed the following command `asar pac my-app app.asar`, but nothing happened due to the typo. However, there was no feedback that indicated that something went wrong. Therefore, in this patch an undefined command will have the following output:

```
$ ./asar pac                                             
asar: 'pac' is not an asar command. See 'asar --help'.
```

The error message is inspired by Git, e.g. when an undefined command is used in Git, it outputs the following.

```
$ git abd
git: 'abc' is not a git command. See 'git --help'.
```

What are your thoughts on this? I am looking forward to receiving feedback when applicable :grimacing: 