### PR TITLE
Making asar compatible with electron + adding functions to remove cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 .node-version
 npm-debug.log
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ npm-debug.log
 appveyor.yml
 .travis.yml
 coffeelint.json
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ branches:
   only:
   - master
 
+install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  - npm install
+
 notifications:
   email:
     on_success: never

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -216,3 +216,11 @@ module.exports.extractAll = function (archive, dest) {
     }
   })
 }
+
+module.exports.uncache = function (archive) {
+  return disk.uncacheFilesystem(archive)
+}
+
+module.exports.uncacheAll = function () {
+  disk.uncacheAll()
+}

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const path = require('path')
 const minimatch = require('minimatch')
 const mkdirp = require('mkdirp')

--- a/lib/crawlfs.js
+++ b/lib/crawlfs.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const glob = require('glob')
 
 module.exports = function (dir, options, callback) {

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -5,7 +5,7 @@ const mkdirp = require('mkdirp')
 const pickle = require('chromium-pickle-js')
 
 const Filesystem = require('./filesystem')
-const filesystemCache = {}
+let filesystemCache = {}
 
 const copyFileToSync = function (dest, src, filename) {
   const srcFile = path.join(src, filename)
@@ -101,6 +101,18 @@ module.exports.readFilesystemSync = function (archive) {
     filesystemCache[archive] = filesystem
   }
   return filesystemCache[archive]
+}
+
+module.exports.uncacheFilesystem = function (archive) {
+  if (filesystemCache[archive]) {
+    filesystemCache[archive] = undefined
+    return true
+  }
+  return false
+}
+
+module.exports.uncacheAll = function () {
+  filesystemCache = {}
 }
 
 module.exports.readFileSync = function (filesystem, filename, info) {

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const path = require('path')
 const mkdirp = require('mkdirp')
 const pickle = require('chromium-pickle-js')

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const path = require('path')
 const tmp = require('tmp')
 const UINT64 = require('cuint').UINT64

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const path = require('path')
 const mksnapshot = require('mksnapshot')
 const vm = require('vm')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/electron/asar/issues"
   },
   "scripts": {
-    "test": "electron-mocha --reporter spec && mocha --reporter spec && npm run lint",
+    "test": "xvfb-maybe electron-mocha --reporter spec && mocha --reporter spec && npm run lint",
     "lint": "standard"
   },
   "standard": {
@@ -43,6 +43,7 @@
     "lodash": "^4.2.1",
     "mocha": "^2.0.1",
     "rimraf": "^2.5.1",
-    "standard": "^8.6.0"
+    "standard": "^8.6.0",
+    "xvfb-maybe": "^0.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/electron/asar/issues"
   },
   "scripts": {
-    "test": "mocha --reporter spec && npm run lint",
+    "test": "electron-mocha --reporter spec && mocha --reporter spec && npm run lint",
     "lint": "standard"
   },
   "standard": {
@@ -38,6 +38,8 @@
     "tmp": "0.0.28"
   },
   "devDependencies": {
+    "electron": "^1.6.2",
+    "electron-mocha": "^3.4.0",
     "lodash": "^4.2.1",
     "mocha": "^2.0.1",
     "rimraf": "^2.5.1",

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -1,6 +1,6 @@
 'use strict'
 const assert = require('assert')
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const os = require('os')
 const path = require('path')
 const rimraf = require('rimraf')
@@ -12,7 +12,7 @@ const transform = require('./util/transformStream')
 
 describe('api', function () {
   beforeEach(function () {
-    rimraf.sync(path.join(__dirname, '..', 'tmp'))
+    rimraf.sync(path.join(__dirname, '..', 'tmp'), fs)
   })
   it('should create archive from directory', function (done) {
     asar.createPackage('test/input/packthis/', 'tmp/packthis-api.asar', function (error) {

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -1,7 +1,7 @@
 'use strict'
 const assert = require('assert')
 const exec = require('child_process').exec
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const os = require('os')
 const path = require('path')
 const rimraf = require('rimraf')
@@ -11,7 +11,7 @@ const compFiles = require('./util/compareFiles')
 
 describe('command line interface', function () {
   beforeEach(function () {
-    rimraf.sync(path.join(__dirname, '..', 'tmp'))
+    rimraf.sync(path.join(__dirname, '..', 'tmp'), fs)
   })
   it('should create archive from directory', function (done) {
     exec('node bin/asar p test/input/packthis/ tmp/packthis-cli.asar', function (error, stdout, stderr) {

--- a/test/util/compareDirectories.js
+++ b/test/util/compareDirectories.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 const path = require('path')
 
 const _ = require('lodash')

--- a/test/util/compareFiles.js
+++ b/test/util/compareFiles.js
@@ -1,6 +1,6 @@
 'use strict'
 const assert = require('assert')
-const fs = require('fs')
+const fs = process.versions.electron ? require('original-fs') : require('fs')
 
 module.exports = function (filepathA, filepathB) {
   const actual = fs.readFileSync(filepathA, 'utf8')


### PR DESCRIPTION
Hello!

I'm building an Electron app and I needed to work with asar packages in it. I then ran in two problems.

First, the official `asar` package didn't work on electron (and the existing `original-fs-asar` uses old code and it does not look like it is maintained).

Second, as I was modifying asar packages, I had problems with the cache mechanism used by `asar`, which often ended up using the header of an asar to read a file in another asar, resulting in output from another file than the one I was reading (wrong offsets).

So, this pull request solves both these issues, making `asar` compatible with electron (of course while still being compatible with node), and adding two methodes to remove the cache.
I'd love to see those features merged into the official `asar`, as I'm sure they could be useful to other people! In the meantime, I published another package with these changes, under the name `asar-original-fs`.

Thank you !