### PR TITLE
Update disk.js to include read location

### DIFF
--- a/lib/disk.js
+++ b/lib/disk.js
@@ -73,14 +73,14 @@ module.exports.readArchiveHeaderSync = function (archive) {
   let headerBuf
   try {
     const sizeBuf = new Buffer(8)
-    if (fs.readSync(fd, sizeBuf, 0, 8, null) !== 8) {
+    if (fs.readSync(fd, sizeBuf, 0, 8, 0) !== 8) {
       throw new Error('Unable to read header size')
     }
 
     const sizePickle = pickle.createFromBuffer(sizeBuf)
     size = sizePickle.createIterator().readUInt32()
     headerBuf = new Buffer(size)
-    if (fs.readSync(fd, headerBuf, 0, size, null) !== size) {
+    if (fs.readSync(fd, headerBuf, 0, size, 0) !== size) {
       throw new Error('Unable to read header')
     }
   } finally {

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -80,7 +80,7 @@ module.exports.readArchiveHeaderSync = function (archive) {
     const sizePickle = pickle.createFromBuffer(sizeBuf)
     size = sizePickle.createIterator().readUInt32()
     headerBuf = new Buffer(size)
-    if (fs.readSync(fd, headerBuf, 0, size, 0) !== size) {
+    if (fs.readSync(fd, headerBuf, 0, size, null) !== size) {
       throw new Error('Unable to read header')
     }
   } finally {


### PR DESCRIPTION
Header position will always be at the beginning of file.  Explicitly stating position 0 guarantees the ready will happen from the start of the file, not the last read location on the [current file descriptor](https://nodejs.org/api/fs.html#fs_fs_read_fd_buffer_offset_length_position_callback).