### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: asar
+version: git
+summary: Manipulate asar archive files
+description: |
+  Asar is a simple extensive archive format, it works like tar that
+  concatenates all files together without compression, while having
+  random access support.
+
+confinement: classic
+
+parts:
+  asar:
+    plugin: nodejs
+    source: .
+
+apps:
+  asar:
+    command: lib/node_modules/asar/bin/asar.js


### PR DESCRIPTION
This pull request adds a `snapcraft.yaml` that will allow `asar` to be hooked up to the [free GitHub integrated Snapcraft build service](https://build.snapcraft.io).

When this pull request is merged visit https://build.snapcraft.io and connect this asar repository. When that is complete builds of `asar` will be created for multiple architectures an published in the edge channel of the snap store so that millions of Linux users and developers are able to easily install `asar` via `snap install asar`.