### PR TITLE
Fix #139: Maximum call stack size exceeded with unpack.

### DIFF
--- a/lib/disk.js
+++ b/lib/disk.js
@@ -22,25 +22,25 @@ const writeFileListToStream = function (dest, filesystem, out, list, metadata, c
     out.end()
     return callback(null)
   }
-
-  const file = list[0]
-  if (file.unpack) {
-    // the file should not be packed into archive.
-    const filename = path.relative(filesystem.src, file.filename)
-    try {
-      copyFileToSync(`${dest}.unpacked`, filesystem.src, filename)
-    } catch (error) {
-      return callback(error)
+  for (let i = 0; i < list.length; i++) {
+    const file = list[i];
+    if (file.unpack) {
+      // the file should not be packed into archive.
+      const filename = path.relative(filesystem.src, file.filename)
+      try {              
+        copyFileToSync(`${dest}.unpacked`, filesystem.src, filename)
+      } catch (error) {        
+        return callback(error)
+      }
+    } else {
+      const tr = metadata[file.filename].transformed
+      const stream = fs.createReadStream((tr ? tr.path : file.filename))
+      stream.pipe(out, {end: false})
+      stream.on('error', callback)
+      return stream.on('end', function () {
+        return writeFileListToStream(dest, filesystem, out, list.slice(i + 1), metadata, callback);
+      })
     }
-    return writeFileListToStream(dest, filesystem, out, list.slice(1), metadata, callback)
-  } else {
-    const tr = metadata[file.filename].transformed
-    const stream = fs.createReadStream((tr ? tr.path : file.filename))
-    stream.pipe(out, {end: false})
-    stream.on('error', callback)
-    return stream.on('end', function () {
-      return writeFileListToStream(dest, filesystem, out, list.slice(1), metadata, callback)
-    })
   }
 }
 

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -23,13 +23,13 @@ const writeFileListToStream = function (dest, filesystem, out, list, metadata, c
     return callback(null)
   }
   for (let i = 0; i < list.length; i++) {
-    const file = list[i];
+    const file = list[i]
     if (file.unpack) {
       // the file should not be packed into archive.
       const filename = path.relative(filesystem.src, file.filename)
-      try {              
+      try {
         copyFileToSync(`${dest}.unpacked`, filesystem.src, filename)
-      } catch (error) {        
+      } catch (error) {
         return callback(error)
       }
     } else {
@@ -38,7 +38,7 @@ const writeFileListToStream = function (dest, filesystem, out, list, metadata, c
       stream.pipe(out, {end: false})
       stream.on('error', callback)
       return stream.on('end', function () {
-        return writeFileListToStream(dest, filesystem, out, list.slice(i + 1), metadata, callback);
+        return writeFileListToStream(dest, filesystem, out, list.slice(i + 1), metadata, callback)
       })
     }
   }


### PR DESCRIPTION
This is a fix for https://github.com/electron/asar/issues/139 which is due to `writeFileListToStream` encountering a large enough span of `unpack` files which in turn causes the function to recurse to the point that it exceeds the maximum call stack size.  The fix eats a span of `unpack` files without recursion, but continues in the non-`unpack` case in the same manner as before. 