### PR TITLE
Proposal: Add is-pack option to "list" command

### DIFF
--- a/bin/asar.js
+++ b/bin/asar.js
@@ -38,11 +38,17 @@ program.command('pack <dir> <output>')
 program.command('list <archive>')
        .alias('l')
        .description('list files of asar archive')
-       .action(function (archive) {
-         var files = asar.listPackage(archive)
+       .option('-i, --is-pack', 'each file in the asar is pack or unpack')
+       .action(function (archive, options) {
+         options = {
+           isPack: options.isPack
+         }
+         var files = asar.listPackage(archive, options)
          for (var i in files) {
            console.log(files[i])
          }
+         // This is in order to disappear help
+         process.exit(0)
        })
 
 program.command('extract-file <archive> <filename>')

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -176,8 +176,8 @@ module.exports.statFile = function (archive, filename, followLinks) {
   return filesystem.getFile(filename, followLinks)
 }
 
-module.exports.listPackage = function (archive) {
-  return disk.readFilesystemSync(archive).listFiles()
+module.exports.listPackage = function (archive, options) {
+  return disk.readFilesystemSync(archive).listFiles(options)
 }
 
 module.exports.extractFile = function (archive, filename) {

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -104,7 +104,7 @@ class Filesystem {
     return link
   }
 
-  listFiles () {
+  listFiles (options) {
     const files = []
     const fillFilesFromHeader = function (p, json) {
       if (!json.files) {
@@ -114,7 +114,8 @@ class Filesystem {
         const result = []
         for (const f in json.files) {
           const fullPath = path.join(p, f)
-          files.push(fullPath)
+          const packState = json.files[f].unpacked === true ? 'unpack' : 'pack  '
+          files.push((options && options.isPack) ? `${packState} : ${fullPath}` : fullPath)
           result.push(fillFilesFromHeader(fullPath, json.files[f]))
         }
         return result

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -48,6 +48,15 @@ describe('api', function () {
     }
     return assert.equal(actual, expected)
   })
+  it('should list files/dirs in archive with option', function () {
+    const actual = asar.listPackage('test/input/extractthis-unpack-dir.asar', {isPack: true}).join('\n')
+    let expected = fs.readFileSync('test/expected/extractthis-filelist-with-option.txt', 'utf8')
+    // on windows replace slashes with backslashes and crlf with lf
+    if (os.platform() === 'win32') {
+      expected = expected.replace(/\//g, '\\').replace(/\r\n/g, '\n')
+    }
+    return assert.equal(actual, expected)
+  })
   it('should extract a text file from archive', function () {
     const actual = asar.extractFile('test/input/extractthis.asar', 'dir1/file1.txt').toString('utf8')
     let expected = fs.readFileSync('test/expected/extractthis/dir1/file1.txt', 'utf8')

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -155,6 +155,18 @@ describe('command line interface', function () {
       done(assert.equal(actual, expected))
     })
   })
+  it('should list files/dirs in archive with unpacked dirs & is-pack option', function (done) {
+    exec('node bin/asar l test/expected/packthis-unpack-dir.asar --is-pack', function (error, stdout, stderr) {
+      if (error != null) return done(error)
+      const actual = stdout
+      let expected = fs.readFileSync('test/expected/extractthis-filelist-with-option.txt', 'utf8') + '\n'
+      // on windows replace slashes with backslashes and crlf with lf
+      if (os.platform() === 'win32') {
+        expected = expected.replace(/\//g, '\\').replace(/\r\n/g, '\n')
+      }
+      done(assert.equal(actual, expected))
+    })
+  })
   it('should extract an archive with unpacked dirs', function (done) {
     exec('node bin/asar e test/input/extractthis-unpack-dir.asar tmp/extractthis-unpack-dir/', function (error, stdout, stderr) {
       if (error != null) return done(error)

--- a/test/expected/extractthis-filelist-with-option.txt
+++ b/test/expected/extractthis-filelist-with-option.txt
@@ -1,0 +1,7 @@
+pack   : /dir1
+pack   : /dir1/file1.txt
+unpack : /dir2
+unpack : /dir2/file2.png
+unpack : /dir2/file3.txt
+pack   : /emptyfile.txt
+pack   : /file0.txt


### PR DESCRIPTION
This pull request adds `--is-pack` option to `list` command to display pack or unpack of each files in the asar. 
Because of I would like to grasp quickly and simply whole of .asar and .asar.unpack.

That output is below, this is simple.
```sh
% ./bin/asar.js list --is-pack ./app.asar                                                                                                                                     
unpack : /x1
unpack : /x1/test
pack   : /x2
```

I hope this patch will be merged.
Best regards.