### PR TITLE
make createPackageFromFiles works

### DIFF
--- a/lib/asar.js
+++ b/lib/asar.js
@@ -62,6 +62,7 @@ callback: The callback function. Accepts (err).
 */
 module.exports.createPackageFromFiles = function (src, dest, filenames, metadata, options, callback) {
   if (typeof metadata === 'undefined' || metadata === null) { metadata = {} }
+  if (typeof options === 'undefined' || options === null) { options = {} }
   const filesystem = new Filesystem(src)
   const files = []
   const unpackDirs = []
@@ -103,7 +104,9 @@ module.exports.createPackageFromFiles = function (src, dest, filenames, metadata
 
     console.log(`Ordering file has ${((total - missing) / total) * 100}% coverage.`)
   } else {
-    filenamesSorted = filenames
+    for (const file of filenames) {
+      filenamesSorted.push(path.join(src, file))
+    }
   }
 
   const handleFile = function (filename, done) {
@@ -115,6 +118,7 @@ module.exports.createPackageFromFiles = function (src, dest, filenames, metadata
       if (stat.isFile()) { type = 'file' }
       if (stat.isSymbolicLink()) { type = 'link' }
       file = {stat, type}
+      metadata[filename] = file
     }
 
     let shouldUnpack

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -105,7 +105,7 @@ module.exports.createPackageFromFiles = function (src, dest, filenames, metadata
     console.log(`Ordering file has ${((total - missing) / total) * 100}% coverage.`)
   } else {
     for (const file of filenames) {
-      filenamesSorted.push(path.join(src, file))
+      filenamesSorted.push(file.startsWith(src) ? file : path.join(src, file))
     }
   }
 


### PR DESCRIPTION
make createPackageFromFiles works without providing any options or metadata

calling like
`asar.createPackageFromFiles(toPath, fileName, paths, null, null, console.log)`
was not allowed.