### PR TITLE
Test against supported LTS Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ skip_tags: true
 
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Node 4 no longer receives updates, and Node 10 has started LTS support.