### PR TITLE
fix: Normalized filepaths in createPackageFromFiles

### DIFF
--- a/lib/asar.js
+++ b/lib/asar.js
@@ -63,6 +63,11 @@ callback: The callback function. Accepts (err).
 module.exports.createPackageFromFiles = function (src, dest, filenames, metadata, options, callback) {
   if (typeof metadata === 'undefined' || metadata === null) { metadata = {} }
   if (typeof options === 'undefined' || options === null) { options = {} }
+
+  src = path.normalize(src)
+  dest = path.normalize(dest)
+  filenames = filenames.map(function (filename) { return path.normalize(filename) })
+
   const filesystem = new Filesystem(src)
   const files = []
   const unpackDirs = []

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -20,6 +20,12 @@ describe('api', function () {
       done(compFiles('tmp/packthis-api.asar', 'test/expected/packthis.asar'))
     })
   })
+  it('should create archive with windows-style path separators', function (done) {
+    asar.createPackage('test\\input\\packthis\\', 'tmp\\packthis-api.asar', function (error) {
+      if (error != null) return done(error)
+      done(compFiles('tmp/packthis-api.asar', 'test/expected/packthis.asar'))
+    })
+  })
   it('should create archive from directory (without hidden files)', function (done) {
     asar.createPackageWithOptions('test/input/packthis/', 'tmp/packthis-without-hidden-api.asar', {dot: false}, function (error) {
       if (error != null) return done(error)

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -20,12 +20,14 @@ describe('api', function () {
       done(compFiles('tmp/packthis-api.asar', 'test/expected/packthis.asar'))
     })
   })
-  it('should create archive with windows-style path separators', function (done) {
-    asar.createPackage('test\\input\\packthis\\', 'tmp\\packthis-api.asar', function (error) {
-      if (error != null) return done(error)
-      done(compFiles('tmp/packthis-api.asar', 'test/expected/packthis.asar'))
+  if (os.platform() === 'win32') {
+    it('should create archive with windows-style path separators', function (done) {
+      asar.createPackage('test\\input\\packthis\\', 'tmp\\packthis-api.asar', function (error) {
+        if (error != null) return done(error)
+        done(compFiles('tmp/packthis-api.asar', 'test/expected/packthis.asar'))
+      })
     })
-  })
+  }
   it('should create archive from directory (without hidden files)', function (done) {
     asar.createPackageWithOptions('test/input/packthis/', 'tmp/packthis-without-hidden-api.asar', {dot: false}, function (error) {
       if (error != null) return done(error)

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -19,12 +19,14 @@ describe('command line interface', function () {
       done(compFiles('tmp/packthis-cli.asar', 'test/expected/packthis.asar'))
     })
   })
-  it('should create archive from directory with windows-style path separators', function (done) {
-    exec('node bin/asar p test\\input\\packthis\\ tmp\\packthis-cli.asar', function (error, stdout, stderr) {
-      if (error != null) return done(error)
-      done(compFiles('tmp/packthis-cli.asar', 'test/expected/packthis.asar'))
+  if (os.platform() === 'win32') {
+    it('should create archive from directory with windows-style path separators', function (done) {
+      exec('node bin/asar p test\\input\\packthis\\ tmp\\packthis-cli.asar', function (error, stdout, stderr) {
+        if (error != null) return done(error)
+        done(compFiles('tmp/packthis-cli.asar', 'test/expected/packthis.asar'))
+      })
     })
-  })
+  }
   it('should create archive from directory without hidden files', function (done) {
     exec('node bin/asar p test/input/packthis/ tmp/packthis-without-hidden-cli.asar --exclude-hidden', function (error, stdout, stderr) {
       if (error != null) return done(error)

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -19,6 +19,12 @@ describe('command line interface', function () {
       done(compFiles('tmp/packthis-cli.asar', 'test/expected/packthis.asar'))
     })
   })
+  it('should create archive from directory with windows-style path separators', function (done) {
+    exec('node bin/asar p test\\input\\packthis\\ tmp\\packthis-cli.asar', function (error, stdout, stderr) {
+      if (error != null) return done(error)
+      done(compFiles('tmp/packthis-cli.asar', 'test/expected/packthis.asar'))
+    })
+  })
   it('should create archive from directory without hidden files', function (done) {
     exec('node bin/asar p test/input/packthis/ tmp/packthis-without-hidden-cli.asar --exclude-hidden', function (error, stdout, stderr) {
       if (error != null) return done(error)


### PR DESCRIPTION
- Candidate fix for the regression introduced in commit #154. 
- Added path normalization to the arguments of createPackageFromFiles.
- Added unit tests which would otherwise fail if the paths are not normalized.
- This is my first pull request ever on GitHub, please be gentle :)