### PR TITLE
chore: remove unused insertLink() `stat` arg

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -94,7 +94,7 @@ class Filesystem {
     }
   }
 
-  insertLink (p, stat) {
+  insertLink (p) {
     const link = path.relative(fs.realpathSync(this.src), fs.realpathSync(p))
     if (link.substr(0, 2) === '..') {
       throw new Error(`${p}: file links out of the package`)


### PR DESCRIPTION
Ref #160 - removes the now-unused `stat` parameter from `insertLink()`.