### PR TITLE
fix: don't monkeypatch fs with promisified versions

### DIFF
--- a/lib/wrapped-fs.js
+++ b/lib/wrapped-fs.js
@@ -5,7 +5,7 @@ const { promisify } = require('util')
 const fs = process.versions.electron ? require('original-fs') : require('fs')
 const mkdirp = require('mkdirp')
 
-const methods = [
+const promisifiedMethods = [
   'lstat',
   'readFile',
   'stat',
@@ -14,8 +14,12 @@ const methods = [
 
 const promisified = {}
 
-for (const method of methods) {
-  promisified[method] = promisify(fs[method])
+for (const method of Object.keys(fs)) {
+  if (promisifiedMethods.includes(method)) {
+    promisified[method] = promisify(fs[method])
+  } else {
+    promisified[method] = fs[method]
+  }
 }
 // To make it more like fs-extra
 promisified.mkdirp = promisify(mkdirp)

--- a/lib/wrapped-fs.js
+++ b/lib/wrapped-fs.js
@@ -12,11 +12,13 @@ const methods = [
   'writeFile'
 ]
 
+const promisified = {}
+
 for (const method of methods) {
-  fs[method] = promisify(fs[method])
+  promisified[method] = promisify(fs[method])
 }
 // To make it more like fs-extra
-fs.mkdirp = promisify(mkdirp)
-fs.mkdirpSync = mkdirp.sync
+promisified.mkdirp = promisify(mkdirp)
+promisified.mkdirpSync = mkdirp.sync
 
-module.exports = fs
+module.exports = promisified


### PR DESCRIPTION
Discovered this bug when trying to upgrade Electron Packager. The `resolve` module never completes when `fs.readFile` is monkeypatched.