### PR TITLE
chore: remove unnecessary arguments

### DIFF
--- a/lib/asar.js
+++ b/lib/asar.js
@@ -129,7 +129,7 @@ module.exports.createPackageFromFiles = async function (src, dest, filenames, me
         files.push({ filename: filename, unpack: shouldUnpack })
         return filesystem.insertFile(filename, shouldUnpack, file, options)
       case 'link':
-        filesystem.insertLink(filename, file.stat)
+        filesystem.insertLink(filename)
         break
     }
     return Promise.resolve()


### PR DESCRIPTION
`file.stat` is unnecessary