### PR TITLE
fix: enforce Node version constraint for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ all files together without compression, while having random access support.
 
 ### Install
 
+This module requires Node 10 or later.
+
 ```bash
-$ npm install asar
+$ npm install --engine-strict asar
 ```
 
 ### Usage

--- a/bin/asar.js
+++ b/bin/asar.js
@@ -1,8 +1,21 @@
 #!/usr/bin/env node
+
+var packageJSON = require('../package.json')
+var splitVersion = function (version) { return version.split('.').map(function (part) { return Number(part) }) }
+var requiredNodeVersion = splitVersion(packageJSON.engines.node.slice(2))
+var actualNodeVersion = splitVersion(process.versions.node)
+
+if (actualNodeVersion[0] < requiredNodeVersion[0] || (actualNodeVersion[0] == requiredNodeVersion[0] && actualNodeVersion[1] < requiredNodeVersion[1])) {
+  console.error('CANNOT RUN WITH NODE ' + process.versions.node)
+  console.error('asar requires Node ' + packageJSON.engines.node + '.')
+  process.exit(1)
+}
+
+// Not consts so that this file can load in Node < 4.0
 var asar = require('../lib/asar')
 var program = require('commander')
 
-program.version('v' + require('../package.json').version)
+program.version('v' + packageJSON.version)
   .description('Manipulate asar archive files')
 
 program.command('pack <dir> <output>')

--- a/bin/asar.js
+++ b/bin/asar.js
@@ -5,7 +5,7 @@ var splitVersion = function (version) { return version.split('.').map(function (
 var requiredNodeVersion = splitVersion(packageJSON.engines.node.slice(2))
 var actualNodeVersion = splitVersion(process.versions.node)
 
-if (actualNodeVersion[0] < requiredNodeVersion[0] || (actualNodeVersion[0] == requiredNodeVersion[0] && actualNodeVersion[1] < requiredNodeVersion[1])) {
+if (actualNodeVersion[0] < requiredNodeVersion[0] || (actualNodeVersion[0] === requiredNodeVersion[0] && actualNodeVersion[1] < requiredNodeVersion[1])) {
   console.error('CANNOT RUN WITH NODE ' + process.versions.node)
   console.error('asar requires Node ' + packageJSON.engines.node + '.')
   process.exit(1)


### PR DESCRIPTION
This is a variation on the [version checking code in the Electron Packager CLI](https://github.com/electron/electron-packager/blob/4081666b32ba5525b84491123344e9908a9cb21d/bin/electron-packager.js#L5-L12).

Also mention the Node version requirement in the README.

Fixes #192 