### PR TITLE
fix: CreateOptions.transform should return stream

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,7 @@ export type CreateOptions = {
   globOptions?: GlobOptions;
   ordering?: string;
   pattern?: string;
-  transform?: (filePath: string) => string;
+  transform?: (filePath: string) => NodeJS.ReadWriteStream | void;
   unpack?: string;
   unpackDir?: string;
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,7 @@ export type CreateOptions = {
   globOptions?: GlobOptions;
   ordering?: string;
   pattern?: string;
-  transform?: (filePath: string) => NodeJS.ReadWriteStream;
+  transform?: (filePath: string) => NodeJS.ReadWriteStream | void;
   unpack?: string;
   unpackDir?: string;
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,7 @@ export type CreateOptions = {
   globOptions?: GlobOptions;
   ordering?: string;
   pattern?: string;
-  transform?: (filePath: string) => NodeJS.ReadWriteStream | void;
+  transform?: (filePath: string) => NodeJS.ReadWriteStream;
   unpack?: string;
   unpackDir?: string;
 };

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -9,7 +9,11 @@ await asar.createPackageWithOptions('bin', 'tmp/foo.asar', {
   globOptions: {
     debug: true,
   },
-  transform: (filePath: string) => crypto.createCipheriv('aes-256-cbc', crypto.randomBytes(32), crypto.randomBytes(16)).setAutoPadding(true).setEncoding('base64'),
+  transform: (filePath: string) => {
+    if (process.env.TRANSFORM_ASAR) {
+      return crypto.createCipheriv('aes-256-cbc', crypto.randomBytes(32), crypto.randomBytes(16)).setAutoPadding(true).setEncoding('base64')
+    }
+  }
 });
 await asar.createPackageFromFiles('bin', 'tmp/foo.asar', ['bin/asar.js']);
 const stat = fs.statSync('bin/asar.js');

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,5 +1,6 @@
 import * as asar from '..';
 import * as fs from 'fs';
+import * as crypto from 'crypto'
 import { expectType } from 'tsd';
 
 await asar.createPackage('bin', 'tmp/foo.asar');
@@ -8,7 +9,7 @@ await asar.createPackageWithOptions('bin', 'tmp/foo.asar', {
   globOptions: {
     debug: true,
   },
-  transform: (filePath: string) => filePath.replace('/', ':'),
+  transform: (filePath: string) => crypto.createCipheriv('aes-256-cbc', crypto.randomBytes(32), crypto.randomBytes(16)).setAutoPadding(true).setEncoding('base64'),
 });
 await asar.createPackageFromFiles('bin', 'tmp/foo.asar', ['bin/asar.js']);
 const stat = fs.statSync('bin/asar.js');


### PR DESCRIPTION
According to [lib/filesystem.js#L65-L80](https://github.com/electron/asar/blob/3f243e2984b46991d9a535673c2c1ab41c95835d/lib/filesystem.js#L65-L80)

``` js
const transformed = options.transform && options.transform(p)
if (transformed) {
  const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'asar-'))
  const tmpfile = path.join(tmpdir, path.basename(p))
  const out = fs.createWriteStream(tmpfile)
  const readStream = fs.createReadStream(p)

  await pipeline(readStream, transformed, out)
  file.transformed = {
    path: tmpfile,
    stat: await fs.lstat(tmpfile)
  }
  size = file.transformed.stat.size
} else {
  size = file.stat.size
}
```