### PR TITLE
fix: js can precisely present MAX_SAFE_INTEGER

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -6,8 +6,6 @@ const path = require('path')
 const { promisify } = require('util')
 const stream = require('stream')
 
-const UINT32_MAX = 2 ** 32 - 1
-
 const pipeline = promisify(stream.pipeline)
 
 class Filesystem {
@@ -79,9 +77,9 @@ class Filesystem {
       size = file.stat.size
     }
 
-    // JavaScript cannot precisely present integers >= UINT32_MAX.
-    if (size > UINT32_MAX) {
-      throw new Error(`${p}: file size can not be larger than 4.2GB`)
+    // JavaScript cannot precisely present integers > Number.MAX_SAFE_INTEGER (2**53 - 1)
+    if (size > Number.MAX_SAFE_INTEGER) {
+      throw new Error(`${p}: file size can not be larger than 9PB`)
     }
 
     node.size = size


### PR DESCRIPTION
I'm actually unsure: why was that claim put there?
Or perhaps there is some other reason and I am missing it?