### PR TITLE
docs: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # asar - Electron Archive
 
-[![CircleCI build status](https://circleci.com/gh/electron/asar/tree/main.svg?style=svg)](https://circleci.com/gh/electron/asar/tree/main)
-[![dependencies](http://img.shields.io/david/electron/asar.svg?style=flat-square)](https://david-dm.org/electron/asar)
-[![npm version](http://img.shields.io/npm/v/asar.svg?style=flat-square)](https://npmjs.org/package/asar)
+[![CircleCI build status](https://circleci.com/gh/electron/asar/tree/main.svg?style=shield)](https://circleci.com/gh/electron/asar/tree/main)
+[![npm version](http://img.shields.io/npm/v/asar.svg)](https://npmjs.org/package/asar)
 
 Asar is a simple extensive archive format, it works like `tar` that concatenates
 all files together without compression, while having random access support.


### PR DESCRIPTION
tiny change that removes `david-dm.org` (think that's been broken for a while) and uniformizes the badge styles we use.