### PR TITLE
build: update docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ steps-test: &steps-test
         name: Install Linux Dependencies
         command: |
           if [ "`uname`" == "Linux" ]; then
-            sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2 libgtk-3-0 libnss3 libxss1 libxtst6
+            sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2 libgtk-3-0 libnss3 libxss1 libxtst6 xvfb
           fi
     - checkout
     - *step-restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ orbs:
 jobs:
   test-linux-14:
     docker:
-      - image: cimg/node:14.9.3
+      - image: cimg/node:14.19.3
     <<: *steps-test
   test-linux-16:
     docker:
@@ -46,7 +46,7 @@ jobs:
 
   release:
     docker:
-      - image: cimg/node:14.9.3
+      - image: cimg/node:14.19.3
     steps:
       - checkout
       - *step-restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ orbs:
 jobs:
   test-linux-10:
     docker:
-      - image: cimg/node:10
+      - image: cimg/node:10.24.1
     <<: *steps-test
   test-linux-12:
     docker:
-      - image: cimg/node:12
+      - image: cimg/node:12.22.12
     <<: *steps-test
   test-mac:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ orbs:
 jobs:
   test-linux-10:
     docker:
-      - image: circleci/node:10
+      - image: cimg/node:10
     <<: *steps-test
   test-linux-12:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12
     <<: *steps-test
   test-mac:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ steps-test: &steps-test
         name: Install Linux Dependencies
         command: |
           if [ "`uname`" == "Linux" ]; then
-            sudo apt-get install --no-install-recommends -y libasound2 libgtk-3-0 libnss3 libxss1 libxtst6
+            sudo apt-get update && apt-get install --no-install-recommends -y libasound2 libgtk-3-0 libnss3 libxss1 libxtst6
           fi
     - checkout
     - *step-restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,13 @@ version: 2.1
 orbs:
   win: circleci/windows@2.4.0
 jobs:
-  test-linux-10:
+  test-linux-14:
     docker:
-      - image: cimg/node:10.24.1
+      - image: cimg/node:14.9.3
     <<: *steps-test
-  test-linux-12:
+  test-linux-16:
     docker:
-      - image: cimg/node:12.22.12
+      - image: cimg/node:16.15.0
     <<: *steps-test
   test-mac:
     macos:
@@ -57,14 +57,14 @@ workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test-linux-10
-      - test-linux-12
+      - test-linux-14
+      - test-linux-16
       - test-mac
       - test-windows
       - release:
           requires:
-            - test-linux-10
-            - test-linux-12
+            - test-linux-14
+            - test-linux-16
             - test-mac
             - test-windows
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ steps-test: &steps-test
         name: Install Linux Dependencies
         command: |
           if [ "`uname`" == "Linux" ]; then
-            sudo apt-get update && apt-get install --no-install-recommends -y libasound2 libgtk-3-0 libnss3 libxss1 libxtst6
+            sudo apt-get update && sudo apt-get install --no-install-recommends -y libasound2 libgtk-3-0 libnss3 libxss1 libxtst6
           fi
     - checkout
     - *step-restore-cache
@@ -46,7 +46,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.9.3
     steps:
       - checkout
       - *step-restore-cache


### PR DESCRIPTION
After making a trivial PR (#236), I realized that the CircleCI job for Linux was consistently failing.

I made a few upgrades and fixes:
* Run `sudo apt-get update` before `sudo apt-get install`.
* Migrate from deprecated `circleci/node:XX` images to the newer `cimg/node:XX.YY.ZZ` images. Needed to also install` xvfb` here because I think the newer images don't come with it installed.
* Move tests from Node 10/12 to 14/16 (current maintenance/LTS versions).
