### PR TITLE
feat: give better hints when failing due to bad links

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -98,7 +98,7 @@ class Filesystem {
   insertLink (p) {
     const link = path.relative(fs.realpathSync(this.src), fs.realpathSync(p))
     if (link.substr(0, 2) === '..') {
-      throw new Error(`${p}: file links out of the package`)
+      throw new Error(`${p}: file "${link}" links out of the package`)
     }
     const node = this.searchNodeFromPath(p)
     node.link = link


### PR DESCRIPTION
Small tweak to improve the "file links out of the package" error message.

Inspired by https://github.com/electron/electron-rebuild/issues/1024. Giving more information in this error message could make it easier to understand what the problem is and how to solve it.