### PR TITLE
Don't give up when unable to extract some files

### DIFF
--- a/lib/asar.js
+++ b/lib/asar.js
@@ -210,11 +210,10 @@ module.exports.extractAll = function (archive, dest) {
         }
       } catch (e) {
         extractionErrors.push(e)
-        console.log('Unable to extract' + filename);
       }
     }
   }
-  if (extractionErrors) {
+  if (extractionErrors.length) {
     throw AggregateError(extractionErrors, 'Unable to extract some files')
   }
 }

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -208,7 +208,7 @@ module.exports.extractAll = function (archive, dest) {
           fs.chmodSync(destFilename, '755')
         }
       } catch {
-        console.log('Unable to extract' + filename);
+        console.log('Unable to extract' + filename)
       }
     }
   }

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -214,7 +214,9 @@ module.exports.extractAll = function (archive, dest) {
     }
   }
   if (extractionErrors.length) {
-    throw AggregateError(extractionErrors, 'Unable to extract some files')
+    throw new Error(
+      'Unable to extract some files:\n\n' +
+      extractionErrors.map(error => error.stack).join('\n\n'))
   }
 }
 

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -206,9 +206,9 @@ module.exports.extractAll = function (archive, dest) {
         fs.writeFileSync(destFilename, content)
         if (file.executable) {
           fs.chmodSync(destFilename, '755')
-        } catch {
-          console.log('Unable to extract' + filename);
         }
+      } catch {
+        console.log('Unable to extract' + filename);
       }
     }
   }

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -200,11 +200,15 @@ module.exports.extractAll = function (archive, dest) {
       const linkTo = path.join(relativePath, path.basename(file.link))
       fs.symlinkSync(linkTo, destFilename)
     } else {
-      // it's a file, extract it
-      const content = disk.readFileSync(filesystem, filename, file)
-      fs.writeFileSync(destFilename, content)
-      if (file.executable) {
-        fs.chmodSync(destFilename, '755')
+      // it's a file, try to extract it
+      try {
+        const content = disk.readFileSync(filesystem, filename, file)
+        fs.writeFileSync(destFilename, content)
+        if (file.executable) {
+          fs.chmodSync(destFilename, '755')
+        } catch {
+          console.log('Unable to extract' + filename);
+        }
       }
     }
   }

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -180,6 +180,7 @@ module.exports.extractAll = function (archive, dest) {
   // create destination directory
   fs.mkdirpSync(dest)
 
+  const extractionErrors = []
   for (const fullPath of filenames) {
     // Remove leading slash
     const filename = fullPath.substr(1)
@@ -207,10 +208,14 @@ module.exports.extractAll = function (archive, dest) {
         if (file.executable) {
           fs.chmodSync(destFilename, '755')
         }
-      } catch {
-        console.log('Unable to extract' + filename)
+      } catch (e) {
+        extractionErrors.push(e)
+        console.log('Unable to extract' + filename);
       }
     }
+  }
+  if (extractionErrors) {
+    throw AggregateError(extractionErrors, 'Unable to extract some files')
   }
 }
 


### PR DESCRIPTION
When asar is extracting all files in an archive, it gives up when it encounters an error extracting one of them. This means that there are some files that can be extracted, but aren't. This change adds a try/catch block around file extraction so that the rest of the files are extracted if there is an issue with only one or a subset of the files in the archive.