### PR TITLE
fix: bad output on unknown CLI command

### DIFF
--- a/bin/asar.js
+++ b/bin/asar.js
@@ -73,8 +73,8 @@ program.command('extract <archive> <dest>')
   })
 
 program.command('*')
-  .action(function (cmd) {
-    console.log('asar: \'%s\' is not an asar command. See \'asar --help\'.', cmd)
+  .action(function (_cmd, args) {
+    console.log('asar: \'%s\' is not an asar command. See \'asar --help\'.', args[0])
   })
 
 program.parse(process.argv)


### PR DESCRIPTION
Looks like this without PR / before:
![image](https://user-images.githubusercontent.com/19228318/205880566-2a637357-232d-4551-991e-1fbae680cdc3.png)

And with PR, performs as expected:
![image](https://user-images.githubusercontent.com/19228318/205880615-643a8a50-576a-4228-a89e-d9caa48ad2e4.png)