### PR TITLE
fix: properly handle rejections on `createPackageWithOptions`

### DIFF
--- a/bin/asar.js
+++ b/bin/asar.js
@@ -35,11 +35,9 @@ program.command('pack <dir> <output>')
       builddir: options.sb,
       dot: !options.excludeHidden
     }
-    asar.createPackageWithOptions(dir, output, options, function (error) {
-      if (error) {
-        console.error(error.stack)
-        process.exit(1)
-      }
+    asar.createPackageWithOptions(dir, output, options).catch(error => {
+      console.error(error)
+      process.exit(1)
     })
   })
 


### PR DESCRIPTION
Minor cleanup: `asar.createPackageWithOptions` doesn't take a fourth argument, so it's safe to remove it 