### PR TITLE
chore: vendor chromium-pickle-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ There is also an unofficial grunt plugin to generate asar archives at [bwin/grun
 
 ## Format
 
-Asar uses [Pickle][pickle] to safely serialize binary value to file, there is
-also a [node.js binding][node-pickle] of `Pickle` class.
+Asar uses [Pickle][pickle] to safely serialize binary value to file.
 
 The format of asar is very flat:
 
@@ -211,5 +210,4 @@ convert `Number` to UINT64.
 * A integer value `blockSize` representing the size in bytes of each block in the `blocks` hashes above
 
 [pickle]: https://chromium.googlesource.com/chromium/src/+/main/base/pickle.h
-[node-pickle]: https://www.npmjs.org/package/chromium-pickle-js
 [grunt-asar]: https://github.com/bwin/grunt-asar

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -2,7 +2,7 @@
 
 const fs = require('./wrapped-fs')
 const path = require('path')
-const pickle = require('chromium-pickle-js')
+const pickle = require('./pickle')
 
 const Filesystem = require('./filesystem')
 let filesystemCache = {}

--- a/lib/pickle.js
+++ b/lib/pickle.js
@@ -1,0 +1,230 @@
+// sizeof(T).
+const SIZE_INT32 = 4
+const SIZE_UINT32 = 4
+const SIZE_INT64 = 8
+const SIZE_UINT64 = 8
+const SIZE_FLOAT = 4
+const SIZE_DOUBLE = 8
+
+// The allocation granularity of the payload.
+const PAYLOAD_UNIT = 64
+
+// Largest JS number.
+const CAPACITY_READ_ONLY = 9007199254740992
+
+// Aligns 'i' by rounding it up to the next multiple of 'alignment'.
+const alignInt = function (i, alignment) {
+  return i + (alignment - (i % alignment)) % alignment
+}
+
+// PickleIterator reads data from a Pickle. The Pickle object must remain valid
+// while the PickleIterator object is in use.
+const PickleIterator = (function () {
+  function PickleIterator (pickle) {
+    this.payload = pickle.header
+    this.payloadOffset = pickle.headerSize
+    this.readIndex = 0
+    this.endIndex = pickle.getPayloadSize()
+  }
+
+  PickleIterator.prototype.readBool = function () {
+    return this.readInt() !== 0
+  }
+
+  PickleIterator.prototype.readInt = function () {
+    return this.readBytes(SIZE_INT32, Buffer.prototype.readInt32LE)
+  }
+
+  PickleIterator.prototype.readUInt32 = function () {
+    return this.readBytes(SIZE_UINT32, Buffer.prototype.readUInt32LE)
+  }
+
+  PickleIterator.prototype.readInt64 = function () {
+    return this.readBytes(SIZE_INT64, Buffer.prototype.readInt64LE)
+  }
+
+  PickleIterator.prototype.readUInt64 = function () {
+    return this.readBytes(SIZE_UINT64, Buffer.prototype.readUInt64LE)
+  }
+
+  PickleIterator.prototype.readFloat = function () {
+    return this.readBytes(SIZE_FLOAT, Buffer.prototype.readFloatLE)
+  }
+
+  PickleIterator.prototype.readDouble = function () {
+    return this.readBytes(SIZE_DOUBLE, Buffer.prototype.readDoubleLE)
+  }
+
+  PickleIterator.prototype.readString = function () {
+    return this.readBytes(this.readInt()).toString()
+  }
+
+  PickleIterator.prototype.readBytes = function (length, method) {
+    const readPayloadOffset = this.getReadPayloadOffsetAndAdvance(length)
+    if (method != null) {
+      return method.call(this.payload, readPayloadOffset, length)
+    } else {
+      return this.payload.slice(readPayloadOffset, readPayloadOffset + length)
+    }
+  }
+
+  PickleIterator.prototype.getReadPayloadOffsetAndAdvance = function (length) {
+    if (length > this.endIndex - this.readIndex) {
+      this.readIndex = this.endIndex
+      throw new Error('Failed to read data with length of ' + length)
+    }
+    const readPayloadOffset = this.payloadOffset + this.readIndex
+    this.advance(length)
+    return readPayloadOffset
+  }
+
+  PickleIterator.prototype.advance = function (size) {
+    const alignedSize = alignInt(size, SIZE_UINT32)
+    if (this.endIndex - this.readIndex < alignedSize) {
+      this.readIndex = this.endIndex
+    } else {
+      this.readIndex += alignedSize
+    }
+  }
+
+  return PickleIterator
+})()
+
+// This class provides facilities for basic binary value packing and unpacking.
+//
+// The Pickle class supports appending primitive values (ints, strings, etc.)
+// to a pickle instance.  The Pickle instance grows its internal memory buffer
+// dynamically to hold the sequence of primitive values.   The internal memory
+// buffer is exposed as the "data" of the Pickle.  This "data" can be passed
+// to a Pickle object to initialize it for reading.
+//
+// When reading from a Pickle object, it is important for the consumer to know
+// what value types to read and in what order to read them as the Pickle does
+// not keep track of the type of data written to it.
+//
+// The Pickle's data has a header which contains the size of the Pickle's
+// payload.  It can optionally support additional space in the header.  That
+// space is controlled by the header_size parameter passed to the Pickle
+// constructor.
+const Pickle = (function () {
+  function Pickle (buffer) {
+    if (buffer) {
+      this.initFromBuffer(buffer)
+    } else {
+      this.initEmpty()
+    }
+  }
+
+  Pickle.prototype.initEmpty = function () {
+    this.header = Buffer.alloc(0)
+    this.headerSize = SIZE_UINT32
+    this.capacityAfterHeader = 0
+    this.writeOffset = 0
+    this.resize(PAYLOAD_UNIT)
+    this.setPayloadSize(0)
+  }
+
+  Pickle.prototype.initFromBuffer = function (buffer) {
+    this.header = buffer
+    this.headerSize = buffer.length - this.getPayloadSize()
+    this.capacityAfterHeader = CAPACITY_READ_ONLY
+    this.writeOffset = 0
+    if (this.headerSize > buffer.length) {
+      this.headerSize = 0
+    }
+    if (this.headerSize !== alignInt(this.headerSize, SIZE_UINT32)) {
+      this.headerSize = 0
+    }
+    if (this.headerSize === 0) {
+      this.header = Buffer.alloc(0)
+    }
+  }
+
+  Pickle.prototype.createIterator = function () {
+    return new PickleIterator(this)
+  }
+
+  Pickle.prototype.toBuffer = function () {
+    return this.header.slice(0, this.headerSize + this.getPayloadSize())
+  }
+
+  Pickle.prototype.writeBool = function (value) {
+    return this.writeInt(value ? 1 : 0)
+  }
+
+  Pickle.prototype.writeInt = function (value) {
+    return this.writeBytes(value, SIZE_INT32, Buffer.prototype.writeInt32LE)
+  }
+
+  Pickle.prototype.writeUInt32 = function (value) {
+    return this.writeBytes(value, SIZE_UINT32, Buffer.prototype.writeUInt32LE)
+  }
+
+  Pickle.prototype.writeInt64 = function (value) {
+    return this.writeBytes(value, SIZE_INT64, Buffer.prototype.writeInt64LE)
+  }
+
+  Pickle.prototype.writeUInt64 = function (value) {
+    return this.writeBytes(value, SIZE_UINT64, Buffer.prototype.writeUInt64LE)
+  }
+
+  Pickle.prototype.writeFloat = function (value) {
+    return this.writeBytes(value, SIZE_FLOAT, Buffer.prototype.writeFloatLE)
+  }
+
+  Pickle.prototype.writeDouble = function (value) {
+    return this.writeBytes(value, SIZE_DOUBLE, Buffer.prototype.writeDoubleLE)
+  }
+
+  Pickle.prototype.writeString = function (value) {
+    const length = Buffer.byteLength(value, 'utf8')
+    if (!this.writeInt(length)) {
+      return false
+    }
+    return this.writeBytes(value, length)
+  }
+
+  Pickle.prototype.setPayloadSize = function (payloadSize) {
+    return this.header.writeUInt32LE(payloadSize, 0)
+  }
+
+  Pickle.prototype.getPayloadSize = function () {
+    return this.header.readUInt32LE(0)
+  }
+
+  Pickle.prototype.writeBytes = function (data, length, method) {
+    const dataLength = alignInt(length, SIZE_UINT32)
+    const newSize = this.writeOffset + dataLength
+    if (newSize > this.capacityAfterHeader) {
+      this.resize(Math.max(this.capacityAfterHeader * 2, newSize))
+    }
+    if (method != null) {
+      method.call(this.header, data, this.headerSize + this.writeOffset)
+    } else {
+      this.header.write(data, this.headerSize + this.writeOffset, length)
+    }
+    const endOffset = this.headerSize + this.writeOffset + length
+    this.header.fill(0, endOffset, endOffset + dataLength - length)
+    this.setPayloadSize(newSize)
+    this.writeOffset = newSize
+    return true
+  }
+
+  Pickle.prototype.resize = function (newCapacity) {
+    newCapacity = alignInt(newCapacity, PAYLOAD_UNIT)
+    this.header = Buffer.concat([this.header, Buffer.alloc(newCapacity)])
+    this.capacityAfterHeader = newCapacity
+  }
+
+  return Pickle
+})()
+
+module.exports = {
+  createEmpty: function () {
+    return new Pickle()
+  },
+
+  createFromBuffer: function (buffer) {
+    return new Pickle(buffer)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "directory": "test"
   },
   "dependencies": {
-    "chromium-pickle-js": "^0.2.0",
     "commander": "^5.0.0",
     "glob": "^7.1.6",
     "minimatch": "^3.0.4"

--- a/test/pickle-spec.js
+++ b/test/pickle-spec.js
@@ -1,0 +1,12 @@
+const assert = require('assert')
+const Pickle = require('../lib/pickle')
+
+describe('Pickle', function () {
+  it('supports multi-byte characters', function () {
+    const write = Pickle.createEmpty()
+    write.writeString('女の子.txt')
+
+    const read = Pickle.createFromBuffer(write.toBuffer())
+    assert.strictEqual(read.createIterator().readString(), '女の子.txt')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,11 +340,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/minimatch@*":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
-  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
-
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -737,11 +732,6 @@ chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-
-chromium-pickle-js@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
-  integrity sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==
 
 cidr-regex@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
[`electron/node-chromium-pickle-js`](https://github.com/electron/node-chromium-pickle-js) hasn't had a commit in nearly 7 years, and CI is non-operational there (see https://github.com/electron/node-chromium-pickle-js/pull/5).

Let's pull the code from there into this repo so that we can archive that repo.

This is a straight copy with minimal changes:
* `var` to `const`
* `new Buffer` to `Buffer.alloc` to make the linter happy