### PR TITLE
ci: bump Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     <<: *steps-test
   test-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.3.0"
     <<: *steps-test
   test-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
   test-mac:
     macos:
       xcode: "14.3.0"
+    resource_class: macos.x86.medium.gen2
     <<: *steps-test
   test-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     <<: *steps-test
   test-mac:
     macos:
-      xcode: "13.3.0"
+      xcode: "14.0.0"
     <<: *steps-test
   test-windows:
     executor:


### PR DESCRIPTION
The current version is deprecated on CircleCI and will be sunset in the next couple of months.