### PR TITLE
fix: Don't overwrite existing folders

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -51,7 +51,7 @@ class Filesystem {
     if (shouldUnpack) {
       node.unpacked = shouldUnpack
     }
-    node.files = {}
+    node.files = node.files || {}
     return node.files
   }
 


### PR DESCRIPTION
It's amazing that I'm the first one to hit this bug - but if you have a folder structure where `asar` just happens to visit the directory _after_ it's added files, it will overwrite the existing files. That's bad, so this is fixing that.