### PR TITLE
fix: fix bug in filesystem.insertLink

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@2.1.0
-  node: electronjs/node@2.1.0
+  node: electronjs/node@2.2.0
 
 workflows:
   test_and_release:

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -99,7 +99,9 @@ class Filesystem {
   }
 
   insertLink (p) {
-    const link = path.relative(fs.realpathSync(this.src), fs.realpathSync(p))
+    const symlink = fs.readlinkSync(p)
+    const parentPath = path.dirname(p)
+    const link = path.relative(fs.realpathSync(this.src), path.join(parentPath, symlink))
     if (link.substr(0, 2) === '..') {
       throw new Error(`${p}: file "${link}" links out of the package`)
     }


### PR DESCRIPTION
In MacOS, if I run `asar.createPackage()` to pack a folder into `.asar`, which contains "symlink", it would get wrong after I run `asar.extractAll()` from the generated `.asar`.

Let's look at this Beyond Compare result:

<img width="1380" alt="企业微信截图_0ef755c7-3d85-4037-8d72-906e533b1fe1" src="https://github.com/electron/asar/assets/12172868/eeffc214-219b-4c3d-a7d1-8bc88e359c5b">

The folder in left is the origin one, and the folder in right was generated by using `asar.extractAll()` from the origin one's `.asar` ( folderLeft --> folderLeft.asar --> folderRight).

Inside the left folder, file **Resources** were pointed to `Versions/Current/Resources`, but the same file inside the right folder were pointed to `Versions/A/Resources`, it's wrong.