### PR TITLE
chore: bump glob to 9.3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
                 condition:
                   and:
                     - equal: [ node/macos, << matrix.executor >> ]
-                    - equal: [ '14.16', << matrix.node-version >> ]
+                    - equal: [ '18.18', << matrix.node-version >> ]
                 steps:
                   - node/install-rosetta
             - when:
@@ -35,10 +35,7 @@ workflows:
                 - node/windows
               node-version:
                 - '20.9'
-                - '18.17'
-                - '16.20'
-                # Stay below 14.17.0 or nvm tries to download arm64 artifacts which don't exist
-                - '14.16'
+                - '18.18'
       - cfa/release:
           requires:
             - test

--- a/lib/asar.js
+++ b/lib/asar.js
@@ -7,6 +7,7 @@ const minimatch = require('minimatch')
 const Filesystem = require('./filesystem')
 const disk = require('./disk')
 const crawlFilesystem = require('./crawlfs')
+const os = require('os')
 
 /**
  * Whether a directory should be excluded from packing due to the `--unpack-dir" option.
@@ -33,6 +34,12 @@ module.exports.createPackage = async function (src, dest) {
 module.exports.createPackageWithOptions = async function (src, dest, options) {
   const globOptions = options.globOptions ? options.globOptions : {}
   globOptions.dot = options.dot === undefined ? true : options.dot
+
+  // https://github.com/isaacs/node-glob/issues/480
+  if (os.platform() === 'win32') {
+    src = src.split(path.sep).join('/')
+    dest = dest.split(path.sep).join('/')
+  }
 
   const pattern = src + (options.pattern ? options.pattern : '/**/*')
 

--- a/lib/crawlfs.js
+++ b/lib/crawlfs.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const { promisify } = require('util')
-
 const fs = require('./wrapped-fs')
-const glob = promisify(require('glob'))
+const { glob } = require('glob')
 
 async function determineFileType (filename) {
   const stat = await fs.lstat(filename)
@@ -18,8 +16,13 @@ async function determineFileType (filename) {
 
 module.exports = async function (dir, options) {
   const metadata = {}
-  const crawled = await glob(dir, options)
+  let crawled = await glob(dir, options || {})
+
+  // https://github.com/isaacs/node-glob/issues/576
+  crawled = crawled.sort((a, b) => a.localeCompare(b, 'en'))
+
   const results = await Promise.all(crawled.map(async filename => [filename, await determineFileType(filename)]))
+
   const links = []
   const filenames = results.map(([filename, type]) => {
     if (type) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lib/index.d.ts"
   ],
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=18.18.0"
   },
   "license": "MIT",
   "homepage": "https://github.com/electron/asar",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "commander": "^5.0.0",
-    "glob": "^7.1.6",
+    "glob": "^9.3.5",
     "minimatch": "^3.0.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,7 +1170,7 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.3, glob@^7.1.6:
+glob@^7.0.5, glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -1181,6 +1181,16 @@ glob@^7.0.5, glob@^7.1.3, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^9.3.5:
+  version "9.3.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.5.tgz#ca2ed8ca452781a3009685607fdf025a899dfe21"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
 
 global-agent@^3.0.0:
   version "3.0.0"
@@ -1737,6 +1747,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+"lru-cache@^9.1.1 || ^10.0.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
+  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
+
 map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -1826,6 +1841,13 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^8.0.2:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
+  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -1839,6 +1861,16 @@ minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
+  integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
 mkdirp@^0.5.1:
   version "0.5.6"
@@ -2177,6 +2209,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.6.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.10.1.tgz#9ba6bf5aa8500fe9fd67df4f0d9483b2b0bfc698"
+  integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
+  dependencies:
+    lru-cache "^9.1.1 || ^10.0.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This updates the project to use `glob@9.3.5` (not using glob@10 as that looks to be ESM-only and this project does not have ESM support).

The reason for updating `glob` is older versions of `glob` uses `inflight`, which has a [medium-level vulun](https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116) that triggers our Vanta SOC2 compliance monitoring for security issues.

This version of glob no longer works for node 14, so I bumped the engine requirements to 18.