### PR TITLE
fix: Export a "default" property

### DIFF
--- a/src/asar.ts
+++ b/src/asar.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as minimatch from 'minimatch';
+import minimatch from 'minimatch';
 
 import fs from './wrapped-fs';
 import { Filesystem, FilesystemEntry } from './filesystem';
@@ -271,3 +271,16 @@ export function uncache(archivePath: string) {
 export function uncacheAll() {
   disk.uncacheAll();
 }
+
+export default {
+  createPackage,
+  createPackageWithOptions,
+  createPackageFromFiles,
+  statFile,
+  getRawHeader,
+  listPackage,
+  extractFile,
+  extractAll,
+  uncache,
+  uncacheAll,
+};

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -160,4 +160,12 @@ describe('api', function () {
     );
     return compDirs('test/input/packthis-object-prototype/', 'tmp/packthis-object-prototype');
   });
+  it('should export all functions also in the default export', () => {
+    const topLevelFunctions = Object.keys(asar).filter((key) => typeof asar[key] === 'function');
+    const defaultExportFunctions = Object.keys(asar.default).filter(
+      (key) => typeof asar.default[key] === 'function',
+    );
+
+    assert.deepStrictEqual(topLevelFunctions, defaultExportFunctions);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "moduleResolution": "node",
     "declaration": true,
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "esModuleInterop": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Fixes #323 

Older versions of `@electron/asar` exported all its functions at the top-level. TypeScript would take our old module, and if someone (like `@electron/forge`) ran `import asar from "@electron/asar"`, execute the following code:

```js
var asar = __importDefault(require("@electron/asar"))

var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};

// later, in our @electron/forge code:
await asar_1.default.createPackageWithOptions(...)
```

In our old version, that would result in:

```
asar = {
  default: {
     [... all our methods]
  }
}
```

Now, we're setting `__esModule: true`, so TypeScript will just return:

```
asar = {
  default: undefined 
}
```

And therefore, all code that looks like 
```js
await asar_1.default.createPackageWithOptions(...)
```
crashes, because `default` is now `undefined`.