### PR TITLE
fix: re-remove @types/glob from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "prepare": "tsc"
   },
   "dependencies": {
-    "@types/glob": "^7.1.0",
     "commander": "^5.0.0",
     "glob": "^7.1.6",
     "minimatch": "^3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,14 +39,6 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
-"@types/glob@^7.1.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
-  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/http-cache-semantics@*":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"


### PR DESCRIPTION
The @types/glob was removed from `optionalDependencies` by the package maintainer @isaacs in #268. The glob package is now written in TS and shouldn't need @types.

I did see where he originally inlined all the types under lib/index.d.ts but I'm guessing that's no longer needed?