### PR TITLE
Move @types/glob to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "prepare": "tsc"
   },
   "dependencies": {
-    "@types/glob": "^7.1.0",
     "commander": "^5.0.0",
     "glob": "^7.1.6",
     "minimatch": "^3.0.4"
   },
   "devDependencies": {
+    "@types/glob": "^7.1.0",
     "@types/minimatch": "^3.0.5",
     "@types/node": "^12.0.0",
     "electron": "^22.0.0",


### PR DESCRIPTION
Type dependencies should be dev dependencies, that way they won't affect downstream packages.

This change seems to have no negative impacts on building or running tests in the project.

Resolves #330 