### PR TITLE
build: fix repository.url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/electron/asar",
   "repository": {
     "type": "git",
-    "url": "https://github.com/electron/asar.git"
+    "url": "git+https://github.com/electron/asar.git"
   },
   "bugs": {
     "url": "https://github.com/electron/asar/issues"


### PR DESCRIPTION
Clears this warning during publish:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/electron/asar.git"
```