### PR TITLE
fix: use local `glob` types

### DIFF
--- a/src/asar.ts
+++ b/src/asar.ts
@@ -10,7 +10,7 @@ import {
 } from './filesystem';
 import * as disk from './disk';
 import { crawl as crawlFilesystem, determineFileType } from './crawlfs';
-import { IOptions } from 'glob';
+import { IOptions } from './types/glob';
 
 /**
  * Whether a directory should be excluded from packing due to the `--unpack-dir" option.

--- a/src/crawlfs.ts
+++ b/src/crawlfs.ts
@@ -1,8 +1,9 @@
 import { promisify } from 'util';
-import { glob as _glob, IOptions } from 'glob';
+import { glob as _glob } from 'glob';
 
 import fs from './wrapped-fs';
 import { Stats } from 'fs';
+import { IOptions } from './types/glob';
 
 const glob = promisify(_glob);
 

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -1,0 +1,11 @@
+/**
+ * TODO(erikian): remove this file once we upgrade to the latest `glob` version.
+ * https://github.com/electron/asar/pull/332#issuecomment-2435407933
+ */
+declare module 'glob' {
+  export function glob(
+    pattern: string,
+    options: import('./glob').IOptions,
+    cb: (err: Error | null, matches: string[]) => void,
+  ): unknown;
+}

--- a/src/types/glob.ts
+++ b/src/types/glob.ts
@@ -2,17 +2,6 @@
  * TODO(erikian): remove this file once we upgrade to the latest `glob` version.
  * https://github.com/electron/asar/pull/332#issuecomment-2435407933
  */
-
-declare module 'glob' {
-  export function glob(
-    pattern: string,
-    options: IGlobOptions,
-    cb: (err: Error | null, matches: string[]) => void,
-  ): unknown;
-
-  export interface IOptions extends IGlobOptions {}
-}
-
 interface IMinimatchOptions {
   /**
    * Dump a ton of stuff to stderr.
@@ -135,7 +124,7 @@ interface IMinimatchOptions {
   windowsPathsNoEscape?: boolean;
 }
 
-export interface IGlobOptions extends IMinimatchOptions {
+export interface IOptions extends IMinimatchOptions {
   cwd?: string | undefined;
   root?: string | undefined;
   dot?: boolean | undefined;


### PR DESCRIPTION
Follow-up to #336, as pointed out in https://github.com/electron/asar/pull/336#issuecomment-2444739563 I forgot to actually replace the usages of the `IOptions` type from `glob` by our local copy.

Fixes #330.