### PR TITLE
feat: allow providing properties (such as `unpack`) in `ordering` input file

### DIFF
--- a/src/asar.ts
+++ b/src/asar.ts
@@ -80,19 +80,21 @@ async function getFileOrdering(
   const total = filenames.length;
 
   const fileOrderingSorted: FileProperties[] = [];
+  const isAlreadySorted = (file: string) =>
+    fileOrderingSorted.findIndex((config) => file === config.filepath) > -1;
 
-  ordering
-    .filter((config) => !fileOrderingSorted.includes(config) && filenames.includes(config.filepath))
-    .forEach((config) => {
+  for (const config of ordering) {
+    if (!isAlreadySorted(config.filepath) && filenames.includes(config.filepath)) {
       fileOrderingSorted.push(config);
-    });
+    }
+  }
 
-  filenames
-    .filter((file) => fileOrderingSorted.findIndex((config) => file === config.filepath) === -1)
-    .forEach((file) => {
+  for (const file of filenames) {
+    if (!isAlreadySorted(file)) {
       fileOrderingSorted.push({ filepath: file, properties: {} });
       missing += 1;
-    });
+    }
+  }
 
   console.log(`Ordering file has ${((total - missing) / total) * 100}% coverage.`);
   return fileOrderingSorted;

--- a/src/asar.ts
+++ b/src/asar.ts
@@ -33,6 +33,71 @@ function isUnpackedDir(dirPath: string, pattern: string, unpackDirs: string[]) {
   }
 }
 
+export type FileProperties = {
+  filepath: string;
+  properties: {
+    unpack?: boolean;
+  };
+};
+
+async function getFileOrdering(
+  options: CreateOptions,
+  src: string,
+  filenames: string[],
+): Promise<FileProperties[]> {
+  if (!options.ordering) {
+    return filenames.map<FileProperties>((filepath) => ({ filepath, properties: {} }));
+  }
+  const orderingMap: FileProperties[] = (await fs.readFile(options.ordering))
+    .toString()
+    .split('\n')
+    .map<FileProperties>((line) => {
+      line = line.trim()
+      const config: FileProperties = { filepath: line, properties: {} };
+      const colonIndex = line.indexOf(":")
+      if (colonIndex > -1) {
+        config.filepath = line.substring(0, colonIndex); // file path
+        const props = line.substring(colonIndex + 1) // props on other side of the `:`
+        config.properties = props.length > 2 ? JSON.parse(props) : {}; // file properties
+      }
+      if (config.filepath.startsWith('/')) {
+        config.filepath = config.filepath.slice(1);
+      }
+      return config;
+    });
+
+  const ordering: FileProperties[] = [];
+  for (const config of orderingMap) {
+    const pathComponents = config.filepath.split(path.sep);
+    let str = src;
+    for (const pathComponent of pathComponents) {
+      str = path.join(str, pathComponent);
+      ordering.push({ filepath: str, properties: config.properties });
+    }
+  }
+
+  let missing = 0;
+  const total = filenames.length;
+
+  const fileOrderingSorted: FileProperties[] = [];
+
+  ordering
+    .filter((config) => !fileOrderingSorted.includes(config) && filenames.includes(config.filepath))
+    .forEach((config) => {
+      fileOrderingSorted.push(config);
+    });
+
+  filenames
+    .filter((file) => fileOrderingSorted.findIndex((config) => file === config.filepath) === -1)
+    .forEach((file) => {
+      fileOrderingSorted.push({ filepath: file, properties: {} });
+      missing += 1;
+    });
+
+  console.log(`Ordering file has ${((total - missing) / total) * 100}% coverage.`);
+  return fileOrderingSorted;
+}
+
 export async function createPackage(src: string, dest: string) {
   return createPackageWithOptions(src, dest, {});
 }
@@ -84,54 +149,10 @@ export async function createPackageFromFiles(
   const links: disk.BasicFilesArray = [];
   const unpackDirs: string[] = [];
 
-  let filenamesSorted: string[] = [];
-  if (options.ordering) {
-    const orderingFiles = (await fs.readFile(options.ordering))
-      .toString()
-      .split('\n')
-      .map((line) => {
-        if (line.includes(':')) {
-          line = line.split(':').pop()!;
-        }
-        line = line.trim();
-        if (line.startsWith('/')) {
-          line = line.slice(1);
-        }
-        return line;
-      });
+  const filenamesSorted: FileProperties[] = await getFileOrdering(options, src, filenames);
 
-    const ordering: string[] = [];
-    for (const file of orderingFiles) {
-      const pathComponents = file.split(path.sep);
-      let str = src;
-      for (const pathComponent of pathComponents) {
-        str = path.join(str, pathComponent);
-        ordering.push(str);
-      }
-    }
-
-    let missing = 0;
-    const total = filenames.length;
-
-    for (const file of ordering) {
-      if (!filenamesSorted.includes(file) && filenames.includes(file)) {
-        filenamesSorted.push(file);
-      }
-    }
-
-    for (const file of filenames) {
-      if (!filenamesSorted.includes(file)) {
-        filenamesSorted.push(file);
-        missing += 1;
-      }
-    }
-
-    console.log(`Ordering file has ${((total - missing) / total) * 100}% coverage.`);
-  } else {
-    filenamesSorted = filenames;
-  }
-
-  const handleFile = async function (filename: string) {
+  const handleFile = async function (config: FileProperties) {
+    const filename = config.filepath
     if (!metadata[filename]) {
       const fileType = await determineFileType(filename);
       if (!fileType) {
@@ -146,6 +167,9 @@ export async function createPackageFromFiles(
       unpack: string | undefined,
       unpackDir: string | undefined,
     ) {
+      if (config.properties.unpack != null) {
+        return config.properties.unpack
+      }
       let shouldUnpack = false;
       if (unpack) {
         shouldUnpack = minimatch(filename, unpack, { matchBase: true });
@@ -190,12 +214,12 @@ export async function createPackageFromFiles(
 
   const names = filenamesSorted.slice();
 
-  const next = async function (name?: string) {
-    if (!name) {
+  const next = async function (config?: FileProperties) {
+    if (!config) {
       return insertsDone();
     }
 
-    await handleFile(name);
+    await handleFile(config);
     return next(names.shift());
   };
 

--- a/src/asar.ts
+++ b/src/asar.ts
@@ -52,12 +52,12 @@ async function getFileOrdering(
     .toString()
     .split('\n')
     .map<FileProperties>((line) => {
-      line = line.trim()
+      line = line.trim();
       const config: FileProperties = { filepath: line, properties: {} };
-      const colonIndex = line.indexOf(":")
+      const colonIndex = line.indexOf(':');
       if (colonIndex > -1) {
         config.filepath = line.substring(0, colonIndex); // file path
-        const props = line.substring(colonIndex + 1) // props on other side of the `:`
+        const props = line.substring(colonIndex + 1); // props on other side of the `:`
         config.properties = props.length > 2 ? JSON.parse(props) : {}; // file properties
       }
       if (config.filepath.startsWith('/')) {
@@ -152,7 +152,7 @@ export async function createPackageFromFiles(
   const filenamesSorted: FileProperties[] = await getFileOrdering(options, src, filenames);
 
   const handleFile = async function (config: FileProperties) {
-    const filename = config.filepath
+    const filename = config.filepath;
     if (!metadata[filename]) {
       const fileType = await determineFileType(filename);
       if (!fileType) {
@@ -168,7 +168,7 @@ export async function createPackageFromFiles(
       unpackDir: string | undefined,
     ) {
       if (config.properties.unpack != null) {
-        return config.properties.unpack
+        return config.properties.unpack;
       }
       let shouldUnpack = false;
       if (unpack) {

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -191,14 +191,11 @@ describe('command line interface', function () {
     );
   });
   it('should unpack static framework with all underlying symlinks unpacked', async () => {
-    const { tmpPath, ordering } = createSymlinkApp('ordered-app');
+    const { tmpPath, buildOrderingData } = createSymlinkApp('ordered-app');
     const orderingPath = path.join(tmpPath, "../ordered-app-ordering.txt");
-
+    
     // this is functionally the same as `-unpack *.txt --unpack-dir var`
-    const data = ordering.reduce((prev, curr) => {
-      const props = { unpack: curr.endsWith(".txt") || curr.includes("var") };
-      return `${prev}${curr}:${JSON.stringify(props)}\n`;
-    }, "");
+    const data = buildOrderingData(filepath => ({ unpack: filepath.endsWith(".txt") || filepath.includes("var") }))
     await writeFile(orderingPath, data)
     
     await execAsar(

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -191,12 +191,14 @@ describe('command line interface', function () {
   });
   it('should unpack static framework with all underlying symlinks unpacked', async () => {
     const { tmpPath, buildOrderingData } = createSymlinkApp('ordered-app');
-    const orderingPath = path.join(tmpPath, "../ordered-app-ordering.txt");
-    
+    const orderingPath = path.join(tmpPath, '../ordered-app-ordering.txt');
+
     // this is functionally the same as `-unpack *.txt --unpack-dir var`
-    const data = buildOrderingData(filepath => ({ unpack: filepath.endsWith(".txt") || filepath.includes("var") }))
-    await fs.writeFile(orderingPath, data)
-    
+    const data = buildOrderingData((filepath) => ({
+      unpack: filepath.endsWith('.txt') || filepath.includes('var'),
+    }));
+    await fs.writeFile(orderingPath, data);
+
     await execAsar(
       `p ${tmpPath} tmp/packthis-with-symlink.asar --ordering=${orderingPath} --exclude-hidden`,
     );

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -12,7 +12,6 @@ const compDirs = require('./util/compareDirectories');
 const compFileLists = require('./util/compareFileLists');
 const { compFiles } = require('./util/compareFiles');
 const createSymlinkApp = require('./util/createSymlinkApp');
-const { writeFile } = require('fs/promises');
 
 const exec = promisify(childProcess.exec);
 
@@ -196,7 +195,7 @@ describe('command line interface', function () {
     
     // this is functionally the same as `-unpack *.txt --unpack-dir var`
     const data = buildOrderingData(filepath => ({ unpack: filepath.endsWith(".txt") || filepath.includes("var") }))
-    await writeFile(orderingPath, data)
+    await fs.writeFile(orderingPath, data)
     
     await execAsar(
       `p ${tmpPath} tmp/packthis-with-symlink.asar --ordering=${orderingPath} --exclude-hidden`,

--- a/test/util/createSymlinkApp.js
+++ b/test/util/createSymlinkApp.js
@@ -30,7 +30,15 @@ module.exports = (testName) => {
   const ordering = walk(tmpPath)
     .map(filepath => filepath.substring(tmpPath.length)) // convert to paths relative to root
 
-  return { appPath, tmpPath, varPath, ordering };
+  return {
+    appPath,
+    tmpPath,
+    varPath,
+    // helper function for generating the `ordering.txt` file data
+    buildOrderingData: (getProps) => ordering.reduce((prev, curr) => {
+      return `${prev}${curr}:${JSON.stringify(getProps(curr))}\n`;
+    }, "")
+  };
 };
 
 // returns a list of all directories, files, and symlinks. Automates testing `ordering` logic easy.

--- a/test/util/createSymlinkApp.js
+++ b/test/util/createSymlinkApp.js
@@ -27,17 +27,17 @@ module.exports = (testName) => {
   fs.mkdirpSync(appPath);
   fs.symlinkSync('../file.txt', path.join(appPath, 'file.txt'));
 
-  const ordering = walk(tmpPath)
-    .map(filepath => filepath.substring(tmpPath.length)) // convert to paths relative to root
+  const ordering = walk(tmpPath).map((filepath) => filepath.substring(tmpPath.length)); // convert to paths relative to root
 
   return {
     appPath,
     tmpPath,
     varPath,
     // helper function for generating the `ordering.txt` file data
-    buildOrderingData: (getProps) => ordering.reduce((prev, curr) => {
-      return `${prev}${curr}:${JSON.stringify(getProps(curr))}\n`;
-    }, "")
+    buildOrderingData: (getProps) =>
+      ordering.reduce((prev, curr) => {
+        return `${prev}${curr}:${JSON.stringify(getProps(curr))}\n`;
+      }, ''),
   };
 };
 


### PR DESCRIPTION
Part 1 for fixing https://github.com/electron/universal/issues/117

This implementation achieves proposal `2b`
Excerpt below:
>Bypass minimatch with more explicit control over packaging options, similar as to asar ordering logic.
b. Leverage `options.ordering` configuration of electron/asar to pass in stringified JSON config for each file to be unpacked

In allowing more explicit control within the ordering file, advanced usage of electron/asar is provided (and kind of needed for electron/universal's current auto-unpack logic) to bypass limitations of the `minimatch` package

------

Right now, the "ordering" file is simply of format:
```
<file path>:<anything>
```
Right now, `electron/asar` only pulls the filename value before the `:`
https://github.com/electron/asar/blob/121efebd2d02e374713cb513eb56a0e3db9534e9/src/asar.ts#L92-L95

This proposal is to leverage `<anything>` to be `JSON.stringify` of Type:
```
{
	unpack: boolean
	// allows for future properties to be added for advanced usage without a breaking change
}
```
Notes:
- Retains the same logic as before for `--ordering` property, just extracted to a separate function
- Adds helper function to the symlinked test app "generator" to easily allow generating `ordering` file sets for any test that wants to leverage it.
- Taking this approach allows future configuration options to be allowed on a per-file basis should electron/asar need/desire to support more advanced usage

