### PR TITLE
fix: revert "feat: allow providing properties (such as `unpack`) in `ordering` input file"

### DIFF
--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -190,17 +190,9 @@ describe('command line interface', function () {
     );
   });
   it('should unpack static framework with all underlying symlinks unpacked', async () => {
-    const { tmpPath, buildOrderingData } = createSymlinkApp('ordered-app');
-    const orderingPath = path.join(tmpPath, '../ordered-app-ordering.txt');
-
-    // this is functionally the same as `-unpack *.txt --unpack-dir var`
-    const data = buildOrderingData((filepath) => ({
-      unpack: filepath.endsWith('.txt') || filepath.includes('var'),
-    }));
-    await fs.writeFile(orderingPath, data);
-
+    const { tmpPath } = createSymlinkApp('app');
     await execAsar(
-      `p ${tmpPath} tmp/packthis-with-symlink.asar --ordering=${orderingPath} --exclude-hidden`,
+      `p ${tmpPath} tmp/packthis-with-symlink.asar --unpack *.txt --unpack-dir var --exclude-hidden`,
     );
 
     assert.ok(fs.existsSync('tmp/packthis-with-symlink.asar.unpacked/private/var/file.txt'));

--- a/test/util/createSymlinkApp.js
+++ b/test/util/createSymlinkApp.js
@@ -26,33 +26,5 @@ module.exports = (testName) => {
   const appPath = path.join(varPath, 'app');
   fs.mkdirpSync(appPath);
   fs.symlinkSync('../file.txt', path.join(appPath, 'file.txt'));
-
-  const ordering = walk(tmpPath).map((filepath) => filepath.substring(tmpPath.length)); // convert to paths relative to root
-
-  return {
-    appPath,
-    tmpPath,
-    varPath,
-    // helper function for generating the `ordering.txt` file data
-    buildOrderingData: (getProps) =>
-      ordering.reduce((prev, curr) => {
-        return `${prev}${curr}:${JSON.stringify(getProps(curr))}\n`;
-      }, ''),
-  };
-};
-
-// returns a list of all directories, files, and symlinks. Automates testing `ordering` logic easy.
-const walk = (root) => {
-  const getPaths = (filepath, filter) =>
-    fs
-      .readdirSync(filepath, { withFileTypes: true })
-      .filter((dirent) => filter(dirent))
-      .map(({ name }) => path.join(filepath, name));
-
-  const dirs = getPaths(root, (dirent) => dirent.isDirectory());
-  const files = dirs.map((dir) => walk(dir)).flat();
-  return files.concat(
-    dirs,
-    getPaths(root, (dirent) => dirent.isFile() || dirent.isSymbolicLink()),
-  );
+  return { appPath, tmpPath, varPath };
 };


### PR DESCRIPTION
Reverts electron/asar#350

This is a breaking change that broke builds against the legacy `asar-ordering.txt` format.