### PR TITLE
feat: allow optional destination field for `asar extract-file` / `asar ef`

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,4 +3,5 @@ module.exports = {
   recursive: true,
   file: './mocha.setup.js', // setup file before everything else loads
   'forbid-only': process.env.CI ?? false, // make sure no `test.only` is merged into `main`
+  reporter: 'spec',
 };

--- a/bin/asar.js
+++ b/bin/asar.js
@@ -55,13 +55,20 @@ program.command('list <archive>')
     }
   })
 
-program.command('extract-file <archive> <filename>')
-  .alias('ef')
-  .description('extract one file from archive')
-  .action(function (archive, filename) {
-    require('fs').writeFileSync(require('path').basename(filename),
-      asar.extractFile(archive, filename))
-  })
+  program
+  .command('extract-file <archive> <filename> [destination]')
+   .alias('ef')
+  .description(
+    'extract one file from archive. Optionally output to (already-existing) destination folder, otherwise cwd will be used',
+  )
+  .action(function (archive, filename, destination) {
+    const path = require('path');
+    const file = path.basename(filename);
+    destination = destination?.trim()
+    const out = destination ? path.join(destination, file) : file;
+    require('fs').writeFileSync(out, asar.extractFile(archive, filename));
+  });
+
 
 program.command('extract <archive> <dest>')
   .alias('e')

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "mocha": "xvfb-maybe electron-mocha --reporter spec && mocha --reporter spec",
+    "mocha": "xvfb-maybe electron-mocha && mocha",
     "mocha:update": "UPDATE_SNAPSHOT=true yarn mocha",
     "mocha:watch": "mocha --watch",
     "test": "yarn lint && yarn mocha",

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -32,6 +32,7 @@ async function assertAsarOutputMatches(args, expectedFilename) {
 describe('command line interface', function () {
   beforeEach(() => {
     rimraf.sync(TEST_APPS_DIR, fs);
+    fs.mkdirSync(TEST_APPS_DIR);
   });
 
   it('should create archive from directory', async () => {
@@ -76,27 +77,24 @@ describe('command line interface', function () {
       'test/expected/packthis-unicode-path-filelist.txt',
     );
   });
-  // we need a way to set a path to extract to first, otherwise we pollute our project dir
-  // or we fake it by setting our cwd, but I don't like that
-  /*
   it('should extract a text file from archive', async () => {
-    await execAsar('ef test/input/extractthis.asar dir1/file1.txt')
-    const actual = await fs.readFile('tmp/file1.txt', 'utf8')
-    let expected = await fs.readFile('test/expected/extractthis/dir1/file1.txt', 'utf8')
+    await execAsar(`ef test/input/extractthis.asar dir1/file1.txt ${TEST_APPS_DIR}`);
+    const actual = await fs.readFile(path.join(TEST_APPS_DIR, 'file1.txt'), 'utf8');
+    let expected = await fs.readFile('test/expected/extractthis/dir1/file1.txt', 'utf8');
     // on windows replace crlf with lf
     if (os.platform() === 'win32') {
-      expected = expected.replace(/\r\n/g, '\n')
+      expected = expected.replace(/\r\n/g, '\n');
     }
-    assert.strictEqual(actual, expected)
-  })
+    assert.strictEqual(actual, expected);
+  });
+  it('should extract a binary file from archive', async () => {
+    await execAsar(`ef test/input/extractthis.asar dir2/file2.png ${TEST_APPS_DIR}`);
+    await compFiles(
+      path.join(TEST_APPS_DIR, 'file2.png'),
+      'test/expected/extractthis/dir2/file2.png',
+    );
+  });
 
-    it('should extract a binary file from archive', async () => {
-      await execAsar('ef test/input/extractthis.asar dir2/file2.png')
-      const actual = await fs.readFile('tmp/file2.png', 'utf8')
-      const expected = await fs.readFile('test/expected/extractthis/dir2/file2.png', 'utf8')
-      assert.strictEqual(actual, expected)
-    })
-  */
   it('should extract an archive', async () => {
     await execAsar('e test/input/extractthis.asar tmp/extractthis-cli/');
     return compDirs('tmp/extractthis-cli/', 'test/expected/extractthis');


### PR DESCRIPTION
Adds an optional parameter to `asar ef` using `[destination]` optional arg syntax

Resolves 2 `it.todo` unit tests with the support of an output directory