### PR TITLE
chore: fix asterisk in help message

### DIFF
--- a/bin/asar.js
+++ b/bin/asar.js
@@ -70,7 +70,7 @@ program.command('extract <archive> <dest>')
     asar.extractAll(archive, dest)
   })
 
-program.command('*')
+program.command('*', { hidden: true})
   .action(function (_cmd, args) {
     console.log('asar: \'%s\' is not an asar command. See \'asar --help\'.', args[0])
   })


### PR DESCRIPTION
The message shown when calling `asar --help` wrongly showed an asterisk as a command.